### PR TITLE
Bugfix: Box_Version was renamed

### DIFF
--- a/library/Registrar/Adapter/Netim.php
+++ b/library/Registrar/Adapter/Netim.php
@@ -696,7 +696,7 @@ class Registrar_Adapter_Netim extends Registrar_AdapterAbstract
             $api = new Netim\APISoap($username, $password, $this->_testMode);
 
             //Don't update setVersion() call, it used by NETIM to track and follow module usage
-            $version = \Box_Version::VERSION;
+            $version = \FOSSBilling_Version::VERSION;
         	$api->setVersion("FOSSB=".$version.",PLUGIN=".self::MODULE_VERSION);
 
 			//Increase synchronization value


### PR DESCRIPTION
We renamed this to `FOSSBilling_Version` in version 0.4.3, so this fixes compatibility with it