### PR TITLE
Update to reflect the namespace changes

### DIFF
--- a/library/Registrar/Adapter/Netim.php
+++ b/library/Registrar/Adapter/Netim.php
@@ -696,7 +696,7 @@ class Registrar_Adapter_Netim extends Registrar_AdapterAbstract
             $api = new Netim\APISoap($username, $password, $this->_testMode);
 
             //Don't update setVersion() call, it used by NETIM to track and follow module usage
-            $version = \FOSSBilling_Version::VERSION;
+            $version = \FOSSBilling\Version::VERSION;
         	$api->setVersion("FOSSB=".$version.",PLUGIN=".self::MODULE_VERSION);
 
 			//Increase synchronization value


### PR DESCRIPTION
In version [0.5.0](https://fossbilling.org/docs/changelog#050-6-13-202), we updated our "FOSSBilling" classes to be under the FOSSBilling namespace and removed the prefix from the names, so this pull request accounts for that